### PR TITLE
Special annotations delete

### DIFF
--- a/maintenance/scripts/delete_annotations.py
+++ b/maintenance/scripts/delete_annotations.py
@@ -21,10 +21,12 @@
 # The namespace can be also "none"
 # Examples
 # delete_annotations.py --anntype file --namespace none username pwd dataset_id
-# will delete all FileAnnotations on a given dataset regardless of namespace
+# will delete all FileAnnotations on images of
+# a given dataset regardless of namespace
 #
 # delete_annotations.py username pwd dataset_id
-# will delete all MapAnnotations with namespace omero.batch_roi_export.map_ann
+# will delete all MapAnnotations with
+# namespace omero.batch_roi_export.map_ann
 
 import argparse
 from omero.gateway import BlitzGateway

--- a/maintenance/scripts/delete_annotations.py
+++ b/maintenance/scripts/delete_annotations.py
@@ -18,23 +18,37 @@
 # ------------------------------------------------------------------------------
 
 # Delete Annotations of a particular namespace from all Images in a Dataset
+# The namespace can be also "none"
+# Examples
+# delete_annotations.py --anntype file --namespace none username pwd dataset_id
+# will delete all FileAnnotations on a given dataset regardless of namespace
+#
+# delete_annotations.py username pwd dataset_id
+# will delete all MapAnnotations with namespace omero.batch_roi_export.map_ann
 
 import argparse
 from omero.gateway import BlitzGateway
+from omero.rtypes import rstring
 import omero
 
 
-def run(username, password, dataset_id, ns, host, port):
+def run(username, password, dataset_id, anntype, ns, host, port):
 
     conn = BlitzGateway(username, password, host=host, port=port)
     try:
         conn.connect()
         dataset = conn.getObject("Dataset", dataset_id)
         ann_ids =[]
+        if anntype == "map":
+            given_type = omero.model.MapAnnotationI
+        if anntype == "file":
+            given_type = omero.model.FileAnnotationI
+        if ns == "none":
+            ns = None
         for image in dataset.listChildren():
-            for a in image.listAnnotations():
-                print a.getId(), a.OMERO_TYPE
-                if a.OMERO_TYPE == omero.model.FileAnnotationI:
+            for a in image.listAnnotations(ns):
+                if a.OMERO_TYPE == given_type:
+                    print a.getId(), a.OMERO_TYPE, a.ns
                     ann_ids.append(a.id)
         if len(ann_ids) > 0:
             print "Deleting %s annotations..." % len(ann_ids)
@@ -50,13 +64,15 @@ def main(args):
     parser.add_argument('username')
     parser.add_argument('password')
     parser.add_argument('dataset_id')
+    parser.add_argument('--anntype', default="map",
+                        help="The namespace of the annotations")
     parser.add_argument('--namespace', default="omero.batch_roi_export.map_ann",
                         help="The namespace of the annotations")
     parser.add_argument('--server', default="outreach.openmicroscopy.org",
                         help="OMERO server hostname")
     parser.add_argument('--port', default=4064, help="OMERO server port")
     args = parser.parse_args(args)
-    run(args.username, args.password, args.dataset_id, args.namespace,
+    run(args.username, args.password, args.dataset_id, args.anntype, args.namespace,
     	args.server, args.port)
 
 

--- a/maintenance/scripts/delete_annotations.py
+++ b/maintenance/scripts/delete_annotations.py
@@ -21,6 +21,7 @@
 
 import argparse
 from omero.gateway import BlitzGateway
+import omero
 
 
 def run(username, password, dataset_id, ns, host, port):
@@ -29,12 +30,15 @@ def run(username, password, dataset_id, ns, host, port):
     try:
         conn.connect()
         dataset = conn.getObject("Dataset", dataset_id)
-
+        ann_ids =[]
         for image in dataset.listChildren():
-            ann_ids = [a.id for a in image.listAnnotations(ns)]
-            if len(ann_ids) > 0:
-                print "Deleting %s annotations..." % len(ann_ids)
-                conn.deleteObjects('Annotation', ann_ids, wait=True)
+            for a in image.listAnnotations():
+                print a.getId(), a.OMERO_TYPE
+                if a.OMERO_TYPE == omero.model.FileAnnotationI:
+                    ann_ids.append(a.id)
+        if len(ann_ids) > 0:
+            print "Deleting %s annotations..." % len(ann_ids)
+            conn.deleteObjects('Annotation', ann_ids, wait=True)
     except Exception as exc:
             print "Error while deleting annotations: %s" % str(exc)
     finally:

--- a/maintenance/scripts/delete_annotations.py
+++ b/maintenance/scripts/delete_annotations.py
@@ -41,6 +41,7 @@ def run(username, password, dataset_id, anntype, ns, host, port):
         conn.connect()
         dataset = conn.getObject("Dataset", dataset_id)
         ann_ids =[]
+        given_type = None
         if anntype == "map":
             given_type = omero.model.MapAnnotationI
         if anntype == "file":


### PR DESCRIPTION
This is trying to widen the https://github.com/ome/training-scripts/blob/master/maintenance/scripts/delete_annotations.py script so that it can be used for all types of annotations (gradually, atm only MapAnn. and FileAnn are possible).
The deletion is possbile when the namespace is defined on the annotations, but also when no namespace is defined. 
This is script is useful for cleaning the first dataset of idr0021 in the workshop practice situation.
Examples of usage are in 
https://github.com/ome/training-scripts/compare/master...pwalczysko:special-annotations-delete?expand=1#diff-df1916a10f19a3d5fab13895a1603711R22

Did https://github.com/ome/training-scripts/compare/master...pwalczysko:special-annotations-delete?expand=1#diff-df1916a10f19a3d5fab13895a1603711R42 because I was not sure how to cast the annotation class into strings in order to be able to compare these with the value of the --anntype given on the CLI.



@will-moore @jburel 