### PR TITLE
fix split view figure console script

### DIFF
--- a/practical/javascript/figure_splitview_layout.js
+++ b/practical/javascript/figure_splitview_layout.js
@@ -27,8 +27,10 @@ figureModel.getSelected().forEach(p => {
         // offset to the right each time we create a new panel
         j.x = j.x + (j.width * 1.05);
         // turn all channels off except for the current index
-        j.channels.forEach((ch, i) => {
-            ch.active = i === c;
+        j.channels = j.channels.map((ch, i) => {
+            var newc = Object.assign({}, ch);
+            newc.active = i === c;
+            return newc;
         });
         // create new panel from json
         figureModel.panels.create(j);


### PR DESCRIPTION
See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2018-September/007203.html

Bug: after running the ```figure_splitview_layout.js``` code, the channels JavaScript object was shared between all the panels, so that all modifications to the channels list were applied to the same object and all panels had just the last channel active in their Model (although this wasn't obvious because they weren't re-rendered each time). See screenshot in e-mail above.

To test:
 - Run the code on a image(s) to create split-view layout
 - Check that each panel's active channels (when selected) match the rendered panel and behave as expected when updated etc.