### PR TITLE
idr0021 import for all workflow

### DIFF
--- a/maintenance/scripts/in_place_import_as.sh
+++ b/maintenance/scripts/in_place_import_as.sh
@@ -45,12 +45,12 @@ do  $OMEROPATH login --sudo ${SUDOER} -u $OMEUSER-$i -s $HOST -w $PASSWORD
     if [ "$DATATYPE" = "dataset" ]; then
         if [ "$IMPORTTYPE" = "normal" ]; then
             DatasetId=$($OMEROPATH obj new Dataset name=$FOLDER)
-            $OMEROPATH import -d $DatasetId --transfer=ln_s "/OMERO/in-place-import/$FOLDER"
+            $OMEROPATH import -d $DatasetId --transfer=ln_s $FOLDER
         elif [ "$IMPORTTYPE" = "bulk" ]; then
             # Create the project
             projectId=`$OMEROPATH obj new Project name=$PROJECTNAME`
             # Get the name of the filepaths.tsv file from the bulk.yml
-            tsv=`grep path: /OMERO/in-place-import/$BULKFILE | cut -d '"' -f2`
+            tsv=`grep path: $BULKFILE | cut -d '"' -f2`
             # Assume it is in the same directory as the bulk.yml
             tsvdir=$(dirname `readlink -f ${BULKFILE}`)
             filepaths=${tsvdir}/${tsv}
@@ -62,10 +62,10 @@ do  $OMEROPATH login --sudo ${SUDOER} -u $OMEUSER-$i -s $HOST -w $PASSWORD
                 linkId=`$OMEROPATH obj new ProjectDatasetLink parent=$projectId child=$datasetId`
             done
             # Then launch the import
-            $OMEROPATH import --bulk "/OMERO/in-place-import/$BULKFILE"
+            $OMEROPATH import --bulk $BULKFILE
         fi
     elif [ "$DATATYPE" = "plate" ]; then
-        $OMEROPATH import --transfer=ln_s "/OMERO/in-place-import/$FOLDER"
+        $OMEROPATH import --transfer=ln_s $FOLDER
     fi
     $OMEROPATH logout
 done

--- a/maintenance/scripts/in_place_import_as.sh
+++ b/maintenance/scripts/in_place_import_as.sh
@@ -17,11 +17,11 @@
 #
 # ------------------------------------------------------------------------------
 
-# This script imports in-place data for 40 different users by default, 
-# user-1 through user-40 into a target dataset.
+# This script imports in-place data for 50 different users by default,
+# user-1 through user-50 into a target dataset.
 # The data is imported by a dedicated user with restricted admin
 # privileges on behalf of other users 
-# i.e. after import each of the 40 users has their own batch of data.
+# i.e. after import each of the 50 users has their own batch of data.
 # Data can also be imported for trainers.
 # To import a dataset for trainers run for example
 # OMEUSER=trainer NUMBER=2 bash in_place_import_as.sh
@@ -34,7 +34,7 @@ OMEROPATH=${OMEROPATH:-/opt/omero/server/OMERO.server/bin/omero}
 PASSWORD=${PASSWORD:-ome}
 HOST=${HOST:-outreach.openmicroscopy.org}
 FOLDER=${FOLDER:-siRNAi-HeLa}
-NUMBER=${NUMBER:-40}
+NUMBER=${NUMBER:-50}
 OMEUSER=${OMEUSER:-user}
 DATATYPE=${DATATYPE:-dataset}
 IMPORTTYPE=${IMPORTTYPE:-normal}

--- a/maintenance/scripts/in_place_import_as.sh
+++ b/maintenance/scripts/in_place_import_as.sh
@@ -37,11 +37,19 @@ FOLDER=${FOLDER:-siRNAi-HeLa}
 NUMBER=${NUMBER:-40}
 OMEUSER=${OMEUSER:-user}
 DATATYPE=${DATATYPE:-dataset}
+IMPORTTYPE=${IMPORTTYPE:-normal}
+CONTAINERS=${CONTAINERS:-idr0021-scripts/idr0021-experimentA-containers.omero}
+BULKFILE=${BULKFILE:-idr0021-scripts/idr0021-experimentA-bulk.yml}
 for ((i=1;i<=$NUMBER;i++));
 do  $OMEROPATH login --sudo ${SUDOER} -u $OMEUSER-$i -s $HOST -w $PASSWORD
     if [ "$DATATYPE" = "dataset" ]; then
-        DatasetId=$($OMEROPATH obj new Dataset name=$FOLDER)
-        $OMEROPATH import -d $DatasetId --transfer=ln_s "/OMERO/in-place-import/$FOLDER"
+        if [ "$IMPORTTYPE" = "normal" ]; then
+            DatasetId=$($OMEROPATH obj new Dataset name=$FOLDER)
+            $OMEROPATH import -d $DatasetId --transfer=ln_s "/OMERO/in-place-import/$FOLDER"
+        elif [ "$IMPORTTYPE" = "bulk" ]; then
+            $OMEROPATH load "/OMERO/in-place-import/$CONTAINERS"
+            $OMEROPATH import --bulk "/OMERO/in-place-import/$BULKFILE"
+        fi
     elif [ "$DATATYPE" = "plate" ]; then
         $OMEROPATH import --transfer=ln_s "/OMERO/in-place-import/$FOLDER"
     fi

--- a/maintenance/scripts/link_dataset_to_existing_project.py
+++ b/maintenance/scripts/link_dataset_to_existing_project.py
@@ -29,14 +29,13 @@ from omero.gateway import BlitzGateway
 from omero.model import DatasetI
 from omero.model import ProjectDatasetLinkI
 from omero.model import ProjectI
-from omero.rtypes import rstring
 
 
 def run(password, project_name, dataset_name, host, port):
 
     for user_number in range(1, 51):
         username = "user-%s" % user_number
-        print username
+        print(username)
         conn = BlitzGateway(username, password, host=host, port=port)
         try:
             conn.connect()
@@ -46,41 +45,41 @@ def run(password, project_name, dataset_name, host, port):
             # make sure only one result is returned by query
             params.page(0, 1)
             query = "from Project where name='%s' \
-                     AND details.owner.omeName=:username ORDER BY id DESC" % project_name
+                    AND details.owner.omeName=:username \
+                    ORDER BY id DESC" % project_name
             service = conn.getQueryService()
             pr_list = service.findAllByQuery(query, params, conn.SERVICE_OPTS)
 
             if pr_list is None:
-                print "No project with name %s found" % project_name
+                print("No project with name %s found" % project_name)
                 continue
 
-
             project_id = pr_list[0].getId().getValue()
-            print username, project_id
+            print(username, project_id)
 
             params = omero.sys.ParametersI()
             params.addString('username', username)
             # make sure only one result is returned by query
             params.page(0, 1)
             query = "from Dataset where name='%s' \
-                     AND details.owner.omeName=:username ORDER BY id DESC" % dataset_name
+                     AND details.owner.omeName=:username \
+                     ORDER BY id DESC" % dataset_name
             service = conn.getQueryService()
             ds_list = service.findAllByQuery(query, params, conn.SERVICE_OPTS)
 
             if ds_list is None:
-                print "No dataset with name %s found" % dataset_name
+                print("No dataset with name %s found" % dataset_name)
                 continue
 
-
             dataset_id = ds_list[0].getId().getValue()
-            print username, dataset_id
+            print(username, dataset_id)
 
             link = ProjectDatasetLinkI()
             link.setParent(ProjectI(project_id, False))
             link.setChild(DatasetI(dataset_id, False))
             conn.getUpdateService().saveObject(link)
         except Exception as exc:
-            print "Error while linking to project: %s" % str(exc)
+            print("Error while linking to project: %s" % str(exc))
         finally:
             conn.close()
 

--- a/maintenance/scripts/link_dataset_to_existing_project.py
+++ b/maintenance/scripts/link_dataset_to_existing_project.py
@@ -43,8 +43,10 @@ def run(password, project_name, dataset_name, host, port):
 
             params = omero.sys.ParametersI()
             params.addString('username', username)
+            # make sure only one result is returned by query
+            params.page(0, 1)
             query = "from Project where name='%s' \
-                     AND details.owner.omeName=:username" % project_name
+                     AND details.owner.omeName=:username ORDER BY id DESC" % project_name
             service = conn.getQueryService()
             pr_list = service.findAllByQuery(query, params, conn.SERVICE_OPTS)
 
@@ -52,14 +54,16 @@ def run(password, project_name, dataset_name, host, port):
                 print "No project with name %s found" % project_name
                 continue
 
-            for pr in pr_list:
-                project_id = pr.getId().getValue()
-                print username, project_id
+
+            project_id = pr_list[0].getId().getValue()
+            print username, project_id
 
             params = omero.sys.ParametersI()
             params.addString('username', username)
+            # make sure only one result is returned by query
+            params.page(0, 1)
             query = "from Dataset where name='%s' \
-                     AND details.owner.omeName=:username" % dataset_name
+                     AND details.owner.omeName=:username ORDER BY id DESC" % dataset_name
             service = conn.getQueryService()
             ds_list = service.findAllByQuery(query, params, conn.SERVICE_OPTS)
 
@@ -67,9 +71,9 @@ def run(password, project_name, dataset_name, host, port):
                 print "No dataset with name %s found" % dataset_name
                 continue
 
-            for ds in ds_list:
-                dataset_id = ds.getId().getValue()
-                print username, dataset_id
+
+            dataset_id = ds_list[0].getId().getValue()
+            print username, dataset_id
 
             link = ProjectDatasetLinkI()
             link.setParent(ProjectI(project_id, False))

--- a/maintenance/scripts/link_dataset_to_existing_project.py
+++ b/maintenance/scripts/link_dataset_to_existing_project.py
@@ -80,7 +80,7 @@ def run(password, project_name, dataset_name, host, port):
             link.setChild(DatasetI(dataset_id, False))
             conn.getUpdateService().saveObject(link)
         except Exception as exc:
-            print "Error while creating project: %s" % str(exc)
+            print "Error while linking to project: %s" % str(exc)
         finally:
             conn.close()
 

--- a/maintenance/scripts/link_dataset_to_existing_project.py
+++ b/maintenance/scripts/link_dataset_to_existing_project.py
@@ -20,7 +20,7 @@
 
 """
 This script looks for a specified project and links it to the specified Dataset
-for users user-1 through user-40.
+for users user-1 through user-50.
 """
 
 import argparse

--- a/maintenance/scripts/link_dataset_to_existing_project.py
+++ b/maintenance/scripts/link_dataset_to_existing_project.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+#
+# -----------------------------------------------------------------------------
+#   Copyright (C) 2017 University of Dundee. All rights reserved.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program; if not, write to the Free Software Foundation, Inc.,
+#   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# ------------------------------------------------------------------------------
+
+"""
+This script looks for a specified project and links it to the specified Dataset
+for users user-1 through user-40.
+"""
+
+import argparse
+import omero
+from omero.gateway import BlitzGateway
+from omero.model import DatasetI
+from omero.model import ProjectDatasetLinkI
+from omero.model import ProjectI
+from omero.rtypes import rstring
+
+
+def run(password, project_name, dataset_name, host, port):
+
+    for user_number in range(1, 3):
+        username = "user-%s" % user_number
+        print username
+        conn = BlitzGateway(username, password, host=host, port=port)
+        try:
+            conn.connect()
+
+            params = omero.sys.ParametersI()
+            params.addString('username', username)
+            query = "from Project where name='%s' \
+                     AND details.owner.omeName=:username" % project_name
+            service = conn.getQueryService()
+            pr_list = service.findAllByQuery(query, params, conn.SERVICE_OPTS)
+
+            if pr_list is None:
+                print "No project with name %s found" % project_name
+                continue
+
+            for pr in pr_list:
+                project_id = pr.getId().getValue()
+                print username, project_id
+
+            params = omero.sys.ParametersI()
+            params.addString('username', username)
+            query = "from Dataset where name='%s' \
+                     AND details.owner.omeName=:username" % dataset_name
+            service = conn.getQueryService()
+            ds_list = service.findAllByQuery(query, params, conn.SERVICE_OPTS)
+
+            if ds_list is None:
+                print "No dataset with name %s found" % dataset_name
+                continue
+
+            for ds in ds_list:
+                dataset_id = ds.getId().getValue()
+                print username, dataset_id
+
+            link = ProjectDatasetLinkI()
+            link.setParent(ProjectI(project_id, False))
+            link.setChild(DatasetI(dataset_id, False))
+            conn.getUpdateService().saveObject(link)
+        except Exception as exc:
+            print "Error while creating project: %s" % str(exc)
+        finally:
+            conn.close()
+
+
+def main(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('password')
+    parser.add_argument('project')
+    parser.add_argument('dataset')
+    parser.add_argument('--server', default="outreach.openmicroscopy.org",
+                        help="OMERO server hostname")
+    parser.add_argument('--port', default=4064, help="OMERO server port")
+    args = parser.parse_args(args)
+    run(args.password, args.project, args.dataset, args.server, args.port)
+
+
+if __name__ == '__main__':
+    import sys
+    main(sys.argv[1:])

--- a/maintenance/scripts/link_dataset_to_existing_project.py
+++ b/maintenance/scripts/link_dataset_to_existing_project.py
@@ -34,7 +34,7 @@ from omero.rtypes import rstring
 
 def run(password, project_name, dataset_name, host, port):
 
-    for user_number in range(1, 3):
+    for user_number in range(1, 51):
         username = "user-%s" % user_number
         print username
         conn = BlitzGateway(username, password, host=host, port=port)

--- a/maintenance/scripts/link_dataset_to_new_project.py
+++ b/maintenance/scripts/link_dataset_to_new_project.py
@@ -20,7 +20,7 @@
 
 """
 This script creates a new project and links it to the specified Datasets
-for users user-1 through user-40.
+for users user-1 through user-50.
 
 Datasets can be specified by a list, passing a "-d $DATASETNAME1 -d $DATASETNAME2 ..."
 pattern to this script.
@@ -42,7 +42,7 @@ from omero.rtypes import rstring
 
 def run(password, project_name, dataset_names, host, port):
 
-    for user_number in range(1, 3):
+    for user_number in range(1, 51):
         username = "user-%s" % user_number
         print username
         conn = BlitzGateway(username, password, host=host, port=port)

--- a/maintenance/scripts/link_dataset_to_new_project.py
+++ b/maintenance/scripts/link_dataset_to_new_project.py
@@ -47,8 +47,10 @@ def run(password, project_name, dataset_name, host, port):
 
             params = omero.sys.ParametersI()
             params.addString('username', username)
+            # make sure only one result is returned by query
+            params.page(0, 1)
             query = "from Dataset where name='%s' \
-                     AND details.owner.omeName=:username" % dataset_name
+                     AND details.owner.omeName=:username ORDER BY id DESC" % dataset_name
             service = conn.getQueryService()
             ds_list = service.findAllByQuery(query, params, conn.SERVICE_OPTS)
 
@@ -56,9 +58,8 @@ def run(password, project_name, dataset_name, host, port):
                 print "No dataset with name %s found" % dataset_name
                 continue
 
-            for ds in ds_list:
-                dataset_id = ds.getId().getValue()
-                print username, dataset_id
+            dataset_id = ds_list[0].getId().getValue()
+            print username, dataset_id
 
             link = ProjectDatasetLinkI()
             link.setParent(ProjectI(project.getId().getValue(), False))

--- a/maintenance/scripts/link_dataset_to_new_project.py
+++ b/maintenance/scripts/link_dataset_to_new_project.py
@@ -22,13 +22,17 @@
 This script creates a new project and links it to the specified Datasets
 for users user-1 through user-50.
 
-Datasets can be specified by a list, passing a "-d $DATASETNAME1 -d $DATASETNAME2 ..."
+Datasets can be specified by a list,
+passing a "-d $DATASETNAME1 -d $DATASETNAME2 ..."
 pattern to this script.
 
 For example, to link all the 10 datasets of the idr0021 study to a new
 project "idr0021" use:
 
-python link_dataset_to_new_project.py $PWD idr0021  -d CDK5RAP2-C -d CENT2 -d CEP120/20111106 -d CEP120/20111209 -d CEP152 -d CEP192-M -d CPAP -d NEDD1-C1 -d PCNT-N1 -d TUBG1-N
+python link_dataset_to_new_project.py
+       $PWD idr0021  -d CDK5RAP2-C -d CENT2 -d CEP120/20111106
+       -d CEP120/20111209 -d CEP152 -d CEP192-M -d CPAP -d NEDD1-C1
+       -d PCNT-N1 -d TUBG1-N
 """
 
 import argparse

--- a/maintenance/scripts/link_dataset_to_new_project.py
+++ b/maintenance/scripts/link_dataset_to_new_project.py
@@ -19,8 +19,16 @@
 # ------------------------------------------------------------------------------
 
 """
-This script creates a new project and links it to the specified Dataset
+This script creates a new project and links it to the specified Datasets
 for users user-1 through user-40.
+
+Datasets can be specified by a list, passing a "-d $DATASETNAME1 -d $DATASETNAME2 ..."
+pattern to this script.
+
+For example, to link all the 10 datasets of the idr0021 study to a new
+project "idr0021" use:
+
+python link_dataset_to_new_project.py $PWD idr0021  -d CDK5RAP2-C -d CENT2 -d CEP120/20111106 -d CEP120/20111209 -d CEP152 -d CEP192-M -d CPAP -d NEDD1-C1 -d PCNT-N1 -d TUBG1-N
 """
 
 import argparse
@@ -32,7 +40,7 @@ from omero.model import ProjectI
 from omero.rtypes import rstring
 
 
-def run(password, project_name, dataset_name, host, port):
+def run(password, project_name, dataset_names, host, port):
 
     for user_number in range(1, 3):
         username = "user-%s" % user_number
@@ -44,38 +52,45 @@ def run(password, project_name, dataset_name, host, port):
             project.setName(rstring(project_name))
             update_service = conn.getUpdateService()
             project = update_service.saveAndReturnObject(project)
-
-            params = omero.sys.ParametersI()
-            params.addString('username', username)
-            # make sure only one result is returned by query
-            params.page(0, 1)
-            query = "from Dataset where name='%s' \
-                     AND details.owner.omeName=:username ORDER BY id DESC" % dataset_name
-            service = conn.getQueryService()
-            ds_list = service.findAllByQuery(query, params, conn.SERVICE_OPTS)
-
-            if ds_list is None:
-                print "No dataset with name %s found" % dataset_name
-                continue
-
-            dataset_id = ds_list[0].getId().getValue()
-            print username, dataset_id
-
-            link = ProjectDatasetLinkI()
-            link.setParent(ProjectI(project.getId().getValue(), False))
-            link.setChild(DatasetI(dataset_id, False))
-            conn.getUpdateService().saveObject(link)
         except Exception as exc:
             print "Error while creating project: %s" % str(exc)
-        finally:
             conn.close()
+            continue
+
+        for dataset_name in dataset_names:
+            try:
+                params = omero.sys.ParametersI()
+                params.addString('username', username)
+                # make sure only one result is returned by query
+                params.page(0, 1)
+                query = "from Dataset where name='%s' \
+                         AND details.owner.omeName=:username ORDER BY id DESC" % dataset_name
+                service = conn.getQueryService()
+                ds_list = service.findAllByQuery(query, params, conn.SERVICE_OPTS)
+
+                if ds_list is None:
+                    print "No dataset with name %s found" % dataset_name
+                    continue
+
+                dataset_id = ds_list[0].getId().getValue()
+                print username, dataset_id
+
+                link = ProjectDatasetLinkI()
+                link.setParent(ProjectI(project.getId().getValue(), False))
+                link.setChild(DatasetI(dataset_id, False))
+                conn.getUpdateService().saveObject(link)
+            except Exception as exc:
+                print "Error while linking dataset to project: %s" % str(exc)
+
+        conn.close()
 
 
 def main(args):
     parser = argparse.ArgumentParser()
     parser.add_argument('password')
     parser.add_argument('project')
-    parser.add_argument('dataset')
+    parser.add_argument('--dataset', '-d', type=str, action='append',
+                        help='One or more datasets to link to the project')
     parser.add_argument('--server', default="outreach.openmicroscopy.org",
                         help="OMERO server hostname")
     parser.add_argument('--port', default=4064, help="OMERO server port")

--- a/maintenance/scripts/link_dataset_to_new_project.py
+++ b/maintenance/scripts/link_dataset_to_new_project.py
@@ -24,6 +24,7 @@ for users user-1 through user-40.
 """
 
 import argparse
+import omero
 from omero.gateway import BlitzGateway
 from omero.model import DatasetI
 from omero.model import ProjectDatasetLinkI
@@ -47,7 +48,7 @@ def run(password, project_name, dataset_name, host, port):
             params = omero.sys.ParametersI()
             params.addString('username', username)
             query = "from Dataset where name='%s' \
-                     AND details.owner.omeName=:username" % target
+                     AND details.owner.omeName=:username" % dataset_name
             service = conn.getQueryService()
             ds_list = service.findAllByQuery(query, params, conn.SERVICE_OPTS)
 
@@ -56,9 +57,8 @@ def run(password, project_name, dataset_name, host, port):
                 continue
 
             for ds in ds_list:
-                dataset_id = ds.getId()
+                dataset_id = ds.getId().getValue()
                 print username, dataset_id
-                date = ds.getAcquisitionDate()
 
             link = ProjectDatasetLinkI()
             link.setParent(ProjectI(project.getId().getValue(), False))


### PR DESCRIPTION
This PR is pushing the enabling scripts to

   - import idr0021 for all (50) users on outreach (even when and if the project, dataset and images are already there for another or the same user for which the import loop is importing at that moment)
   - create a new project and link all datasets specified (by passing ``-d DATASET1 -d DATASET2 -d DATASET3 ...`` to it (even if there are more datasets with the same name for that user, the script should take the one created last and link it to the new project)
   - (meant as a follow-up option, the idr0021 workflow should be covered by the two steps above) link a dataset to  an existing project. This should work even in case there are 2 or more such projects or dtatasets for a given user, it should simply use the most recent project and dataset of that name. 


ToDo: Loop also for all users through the script which adds Map Annotations from IDR to the newly imported idr0021 projects

cc @jburel @sbesson @dominikl 