### PR TITLE
Delete rnd

### DIFF
--- a/maintenance/scripts/delete_rendering.py
+++ b/maintenance/scripts/delete_rendering.py
@@ -20,7 +20,8 @@
 # ------------------------------------------------------------------------------
 
 """
-This script 
+This script finds all rendering on images from a dataset specified
+by dataset id or dataset name and deletes these rendering settings.
 """
 
 import argparse
@@ -33,7 +34,6 @@ def run(name, password, dataset_name, dataset_id, host, port):
     conn = BlitzGateway(name, password, host=host, port=port)
     try:
         conn.connect()
-        roi_service = conn.getRoiService()
         rnd_service = conn.getRenderingSettingsService()
         datasets = []
         if dataset_id >= 0:
@@ -41,24 +41,18 @@ def run(name, password, dataset_name, dataset_id, host, port):
         else:
             datasets = conn.getObjects("Dataset",
                                        attributes={"name": dataset_name})
-        
-        print datasets
 
         for dataset in datasets:
             print dataset.getId()
             for image in dataset.listChildren():
                 pixels = image.getPrimaryPixels()
-                result = roi_service.findByImage(image.getId(), None,
-                                                 conn.SERVICE_OPTS)
-                #result2 = rnd_service.findByImage(image.getId(), None, conn.SERVICE_OPTS)
                 print pixels.getId()
                 params = omero.sys.ParametersI()
                 query = "from RenderingDef where pixels.id = '%s'" % pixels.getId()
                 query_service = conn.getQueryService()
-                result2 = query_service.findAllByQuery(query, params, conn.SERVICE_OPTS)
-                #print result2
-                if result2 is not None:
-                    rnd_ids = [rnd.id.val for rnd in result2]
+                result = query_service.findAllByQuery(query, params, conn.SERVICE_OPTS)
+                if result is not None:
+                    rnd_ids = [rnd.id.val for rnd in result]
                     if len(rnd_ids) > 0:
                         print "Deleting %s rnds..." % len(rnd_ids)
                         print rnd_ids

--- a/maintenance/scripts/delete_rendering.py
+++ b/maintenance/scripts/delete_rendering.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# -----------------------------------------------------------------------------
+#   Copyright (C) 2017 University of Dundee. All rights reserved.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program; if not, write to the Free Software Foundation, Inc.,
+#   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# ------------------------------------------------------------------------------
+
+"""
+This script 
+"""
+
+import argparse
+import omero
+from omero.gateway import BlitzGateway
+
+
+def run(name, password, dataset_name, dataset_id, host, port):
+
+    conn = BlitzGateway(name, password, host=host, port=port)
+    try:
+        conn.connect()
+        roi_service = conn.getRoiService()
+        rnd_service = conn.getRenderingSettingsService()
+        datasets = []
+        if dataset_id >= 0:
+            datasets.append(conn.getObject("Dataset", dataset_id))
+        else:
+            datasets = conn.getObjects("Dataset",
+                                       attributes={"name": dataset_name})
+        
+        print datasets
+
+        for dataset in datasets:
+            print dataset.getId()
+            for image in dataset.listChildren():
+                pixels = image.getPrimaryPixels()
+                result = roi_service.findByImage(image.getId(), None,
+                                                 conn.SERVICE_OPTS)
+                #result2 = rnd_service.findByImage(image.getId(), None, conn.SERVICE_OPTS)
+                print pixels.getId()
+                params = omero.sys.ParametersI()
+                query = "from RenderingDef where pixels.id = '%s'" % pixels.getId()
+                query_service = conn.getQueryService()
+                result2 = query_service.findAllByQuery(query, params, conn.SERVICE_OPTS)
+                #print result2
+                if result2 is not None:
+                    rnd_ids = [rnd.id.val for rnd in result2]
+                    if len(rnd_ids) > 0:
+                        print "Deleting %s rnds..." % len(rnd_ids)
+                        print rnd_ids
+                        conn.deleteObjects("RenderingDef", rnd_ids, wait=True)
+
+    except Exception as exc:
+        print "Error while deleting rendering: %s" % str(exc)
+    finally:
+        conn.close()
+
+
+def main(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('password')
+    parser.add_argument('--datasetid', default=-1,
+                        help="The ID of the dataset")
+    parser.add_argument('--datasetname', default="",
+                        help="The name of the dataset")
+    parser.add_argument('--name', default="trainer-1",
+                        help="The user deleting the rois")
+    parser.add_argument('--server', default="outreach.openmicroscopy.org",
+                        help="OMERO server hostname")
+    parser.add_argument('--port', default=4064, help="OMERO server port")
+    args = parser.parse_args(args)
+    run(args.name, args.password, args.datasetname, args.datasetid,
+        args.server, args.port)
+
+
+if __name__ == '__main__':
+    import sys
+    main(sys.argv[1:])

--- a/maintenance/scripts/delete_rendering.sh
+++ b/maintenance/scripts/delete_rendering.sh
@@ -16,10 +16,9 @@ NUMBER=${NUMBER:-50}
 OMEUSER=${OMEUSER:-trainer-1}
 
 $OMEROPATH login -u $OMEUSER -s $HOST -w $PASSWORD
-result=`$OMEROPATH hql --ids-only --limit 1000 --style plain -q --all "SELECT id from Dataset WHERE name = '$DATASETNAME'"`
 if [ "$DATASETIDS" = "none" ]
 then
-    echo "none ID"
+    result=`$OMEROPATH hql --ids-only --limit 1000 --style plain -q --all "SELECT id from Dataset WHERE name = '$DATASETNAME'"`
     for i in $result
     do
         #remove the ordinal numbers

--- a/maintenance/scripts/delete_rendering.sh
+++ b/maintenance/scripts/delete_rendering.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# This script deletes rnd settings on images in specified Datasets.
+# Datasets can be specified either by name, such as
+# DATASETNAME=svs bash delete_rendering.sh
+# or by IDs (one or more, separated by comma), such as
+# DATASETID=1868,2073 bash delete_rendering.sh
+
+echo Starting
+OMEROPATH=${OMEROPATH:-/opt/omero/server/OMERO.server/bin/omero}
+PASSWORD=${PASSWORD:-ome}
+HOST=${HOST:-outreach.openmicroscopy.org}
+DATASETNAME=${DATASETNAME:-siRNAi-HeLa}
+DATASETIDS=${DATASETID:-none}
+NUMBER=${NUMBER:-50}
+OMEUSER=${OMEUSER:-trainer-1}
+
+$OMEROPATH login -u $OMEUSER -s $HOST -w $PASSWORD
+result=`$OMEROPATH hql --ids-only --limit 1000 --style plain -q --all "SELECT id from Dataset WHERE name = '$DATASETNAME'"`
+if [ "$DATASETIDS" = "none" ]
+then
+    echo "none ID"
+    for i in $result
+    do
+        #remove the ordinal numbers
+        datasetids_raw+=${i#*,}
+        datasetids_raw+=","
+    done
+    dataset_number=${i%,*}
+    #remove the trailing comma
+    datasetids=${datasetids_raw%?}
+else
+    datasetids=$DATASETIDS
+    dataset_number="specified datasets"
+fi
+echo 'Deleting rnd settings on '"$dataset_number"' Datasets:' $datasetids
+$OMEROPATH delete --report Dataset/RenderingDef:$datasetids
+$OMEROPATH logout
+echo Stopping

--- a/maintenance/scripts/delete_rendering.sh
+++ b/maintenance/scripts/delete_rendering.sh
@@ -18,16 +18,9 @@ OMEUSER=${OMEUSER:-trainer-1}
 $OMEROPATH login -u $OMEUSER -s $HOST -w $PASSWORD
 if [ "$DATASETIDS" = "none" ]
 then
-    result=`$OMEROPATH hql --ids-only --limit 1000 --style plain -q --all "SELECT id from Dataset WHERE name = '$DATASETNAME'"`
-    for i in $result
-    do
-        #remove the ordinal numbers
-        datasetids_raw+=${i#*,}
-        datasetids_raw+=","
-    done
-    dataset_number=${i%,*}
-    #remove the trailing comma
-    datasetids=${datasetids_raw%?}
+    result=`$OMEROPATH hql --ids-only --limit 1000 --style plain -q --all "SELECT id from Dataset WHERE name = '$DATASETNAME'" | cut -f 2 -d , | tr '\n' ,`
+    dataset_number=`echo $result | tr -cd , | wc -c | sed -e 's/[[:space:]]*//'`
+    datasetids=`echo $result | sed -e 's/,$//'`
 else
     datasetids=$DATASETIDS
     dataset_number="specified datasets"


### PR DESCRIPTION
This adds a script which deletes all the rnd settings on images from specified dataset(s).
The main goal is to be able to clean the rendering settings of other users as they are viewing each others and trainer-1's images on outreach. There is quite a few settings thumbs in the Preview panel on siRNA-HeLa dataset.

Although the script deletes ALL the rnd settings on each relevant image, the rnd settings are regenerated immediately when the owner (or other person) is viewing the images the first time after this script has been run. Hope this is an acceptable tactics.
cc @jburel @will-moore 

cc @jrswedlow (regards the prep for LA outreach -> follow-up of https://openmicroscopy.slack.com/archives/C1PJHN2D7/p1550422112083100)