### PR TITLE
Add commands for omero-downloader

### DIFF
--- a/practical/bash/downloader-commands
+++ b/practical/bash/downloader-commands
@@ -7,5 +7,5 @@ download.bat -b <path-to-target-dir> -s outreach.openmicroscopy.org -u <user nam
 # To download metadata of images in two datasets with ID1 and ID2
 ./download.sh -b <path-to-target-dir> -s outreach.openmicroscopy.org -u <user name> -w <password> -f ome-xml Dataset:$ID2,$ID1
 
-# To find IDs images tagged with a particular tag in the target directory
-grep   '^<Tag.*Marvin' <path-to-target-dir>/Image/*/Annotation/*/Metadata/*xml
+# To find IDs images tagged with a tag named "your-tag" in the target directory
+grep   '^<Tag.*your-tag' <path-to-target-dir>/Image/*/Annotation/*/Metadata/*xml

--- a/practical/bash/downloader-commands
+++ b/practical/bash/downloader-commands
@@ -1,8 +1,8 @@
 # To download an image on Unix
-./download.sh -b <path-to-target-dir> -s <server host> -u <user name> -w <password> -f binary Image:<image ID>
+./download.sh -b <path-to-target-dir> -s outreach.openmicroscopy.org -u <user name> -w <password> -f binary Image:<image ID>
 
 # To download an image on Windows
-download.bat -b <path-to-target-dir> -s <server host> -u <user name> -w <password> -f binary Image:<image ID>
+download.bat -b <path-to-target-dir> -s outreach.openmicroscopy.org -u <user name> -w <password> -f binary Image:<image ID>
 
 # To download metadata of images in two datasets with ID1 and ID2
 ./download.sh -b <path-to-target-dir> -s outreach.openmicroscopy.org -u <user name> -w <password> -f ome-xml Dataset:$ID2,$ID1

--- a/practical/bash/downloader-commands
+++ b/practical/bash/downloader-commands
@@ -1,0 +1,12 @@
+
+# To download an image on Unix
+./download.sh -b <path-to-target-dir> -s <server host> -u <user name> -w <password> -f binary Image:<image ID>
+
+# To download an image on Windows
+download.bat -b <path-to-target-dir> -s <server host> -u <user name> -w <password> -f binary Image:<image ID>
+
+# To download metadata of images in two datasets with ID1 and ID2
+download.sh -b <path-to-target-dir> -s outreach.openmicroscopy.org -u <user name> -w <password> -f ome-xml Dataset:$ID2,$ID1
+
+# To find IDs images tagged with a particular tag in the target directory
+grep   ‘^<Tag*your-name’ <path-to-target-dir>/Image/*/Annotation/*/Metadata/*xml

--- a/practical/bash/downloader-commands
+++ b/practical/bash/downloader-commands
@@ -1,4 +1,3 @@
-
 # To download an image on Unix
 ./download.sh -b <path-to-target-dir> -s <server host> -u <user name> -w <password> -f binary Image:<image ID>
 
@@ -6,7 +5,7 @@
 download.bat -b <path-to-target-dir> -s <server host> -u <user name> -w <password> -f binary Image:<image ID>
 
 # To download metadata of images in two datasets with ID1 and ID2
-download.sh -b <path-to-target-dir> -s outreach.openmicroscopy.org -u <user name> -w <password> -f ome-xml Dataset:$ID2,$ID1
+./download.sh -b <path-to-target-dir> -s outreach.openmicroscopy.org -u <user name> -w <password> -f ome-xml Dataset:$ID2,$ID1
 
 # To find IDs images tagged with a particular tag in the target directory
 grep   ‘^<Tag*your-name’ <path-to-target-dir>/Image/*/Annotation/*/Metadata/*xml

--- a/practical/bash/downloader-commands
+++ b/practical/bash/downloader-commands
@@ -8,4 +8,4 @@ download.bat -b <path-to-target-dir> -s outreach.openmicroscopy.org -u <user nam
 ./download.sh -b <path-to-target-dir> -s outreach.openmicroscopy.org -u <user name> -w <password> -f ome-xml Dataset:$ID2,$ID1
 
 # To find IDs images tagged with a particular tag in the target directory
-grep   ‘^<Tag*your-name’ <path-to-target-dir>/Image/*/Annotation/*/Metadata/*xml
+grep   '^<Tag.*Marvin' <path-to-target-dir>/Image/*/Annotation/*/Metadata/*xml


### PR DESCRIPTION
In prep of the Oxford workshop, adding a textfile for easy of Copy&Paste of the commands for the downloader section of the workflow.
Search for "Image export using omero-downloade" in https://downloads.openmicroscopy.org/presentations/2019/Dundee-April/Dundee_April_2019_Day1.pdf to see the whole workflow.

cc @dominikl @mtbc @jburel 