### PR TITLE
Set matplotlib backend to 'Agg'

### DIFF
--- a/practical/python/server/simple_frap.py
+++ b/practical/python/server/simple_frap.py
@@ -34,7 +34,10 @@ from omero.rtypes import robject, rstring
 from PIL import Image
 
 import numpy as np
+
 try:
+    import matplotlib
+    matplotlib.use('Agg')
     import matplotlib.pyplot as plt
 except (ImportError, RuntimeError):
     plt = None


### PR DESCRIPTION
matplotlib now needs the backend explicitely set to `'Agg'` for pyplot to work.
/cc @pwalczysko 