### PR TITLE
Idr0021.groovy headers no whitespace

### DIFF
--- a/practical/groovy/idr0021.groovy
+++ b/practical/groovy/idr0021.groovy
@@ -392,15 +392,15 @@ def save_summary_as_csv(file, rows, columns) {
     sb = new StringBuilder()
     try {
         stream = new PrintWriter(file)
-        l = table_columns.length
+        l = columns.length
         for (i = 0; i < l; i++) {
-            sb.append(table_columns[i].getName())
+            sb.append(columns[i].getName())
             if (i != (l-1)) {
                 sb.append(", ")
             }
         }
         sb.append("\n")
-        table_rows.each() { row ->
+        rows.each() { row ->
             size = row.size()
             for (i = 0; i < size; i++) {
                 value = row.get(i)

--- a/practical/groovy/idr0021.groovy
+++ b/practical/groovy/idr0021.groovy
@@ -263,6 +263,8 @@ def create_table_columns(headings) {
     //populate the headings
     for (h = 0; h < size; h++) {
         heading = headings[h]
+        // OMERO.tables queries don't handle whitespace well
+        heading = heading.replace(" ", "_")
         if (heading.equals("Slice") || heading.equals("Dataset") || heading.equals("Label")) {
             table_columns[h] = new TableDataColumn(heading, h, String)
         } else {


### PR DESCRIPTION
Since we can't use OMERO.tables queries if the column names have whitespace, it's better to remove whitespace from OMERO.tables column names.

After running locally...
![Screenshot 2020-02-27 at 13 58 33](https://user-images.githubusercontent.com/900055/75518615-40604080-59f9-11ea-8f78-cf43c97d5c61.png)


Also cleaned-up a slightly confusing usage of global variables.