### PR TITLE
Add --ignore_datasets option to idr_get_map_annotations.py

### DIFF
--- a/maintenance/scripts/delete_ROIs.py
+++ b/maintenance/scripts/delete_ROIs.py
@@ -30,7 +30,7 @@ def run(name, password, dataset_name, dataset_id, host, port):
         conn.connect()
         roi_service = conn.getRoiService()
         datasets = []
-        if dataset_id >= 0:
+        if int(dataset_id) >= 0:
             datasets.append(conn.getObject("Dataset", dataset_id))
         else:
             datasets = conn.getObjects("Dataset",


### PR DESCRIPTION
While preparing data for the [OME2021 figure workshop](https://github.com/ome/omero-figure/issues/431) I needed a couple of different features / scripts.

In progress...

 - When copying map annotations from Images in a Project on IDR to local Images, the Dataset names locally are different (Images in different Datasets on IDR and in a single Dataset locally). I added an `--ignore_datasets` argument to support this:
 ```$ python idr_get_map_annotations.py will ome Project:1102 Project:1301 --server localhost --ignore_datasets```