### PR TITLE
Fix help text of delete_ann

### DIFF
--- a/maintenance/scripts/delete_annotations.py
+++ b/maintenance/scripts/delete_annotations.py
@@ -76,7 +76,7 @@ def main(args):
     parser.add_argument('--name', default="trainer-1",
                         help="The user deleting the annotations")
     parser.add_argument('--anntype', default="map",
-                        help="The namespace of the annotations")
+                        help="The type of the annotations")
     parser.add_argument('--namespace',
                         default="omero.batch_roi_export.map_ann",
                         help="The namespace of the annotations")


### PR DESCRIPTION
Small fix of the imprecise help text of the ``delete_annotations.py`` script.

