### PR TITLE
Channel minmax to table fixes

### DIFF
--- a/maintenance/scripts/channel_minmax_to_table.py
+++ b/maintenance/scripts/channel_minmax_to_table.py
@@ -94,10 +94,11 @@ def run(plate_id):
 
         print("Adding data: ", len(data))
         table.addData(data)
+
+        # get original file before closing...
+        orig_file = table.getOriginalFile()
         table.close()
 
-        print("table closed...")
-        orig_file = table.getOriginalFile()
         fileAnn = omero.model.FileAnnotationI()
         fileAnn.ns = rstring(NAMESPACE)
         fileAnn.setFile(omero.model.OriginalFileI(orig_file.id.val, False))

--- a/maintenance/scripts/channel_minmax_to_table.py
+++ b/maintenance/scripts/channel_minmax_to_table.py
@@ -21,6 +21,7 @@
 
 import argparse
 import omero
+from omero.cli import cli_login
 from omero.rtypes import rstring
 import omero.grid
 from omero.gateway import BlitzGateway
@@ -29,11 +30,10 @@ from omero.gateway import BlitzGateway
 NAMESPACE = "openmicroscopy.org/omero/bulk_annotations"
 
 
-def run(username, password, plate_id, host, port):
+def run(plate_id):
 
-    conn = BlitzGateway(username, password, host=host, port=port)
-    try:
-        conn.connect()
+    with cli_login() as cli:
+        conn = BlitzGateway(client_obj=cli._client)
         query_service = conn.getQueryService()
 
         # Create a name for the Original File
@@ -109,22 +109,13 @@ def run(username, password, plate_id, host, port):
         print("save link...")
         conn.getUpdateService().saveAndReturnObject(link)
 
-    except Exception as exc:
-        print("Error while changing names: %s" % str(exc))
-    finally:
-        conn.close()
-
 
 def main(args):
     parser = argparse.ArgumentParser()
-    parser.add_argument('username')
-    parser.add_argument('password')
     parser.add_argument('plate_id')
-    parser.add_argument('--server', default="workshop.openmicroscopy.org",
-                        help="OMERO server hostname")
-    parser.add_argument('--port', default=4064, help="OMERO server port")
     args = parser.parse_args(args)
-    run(args.username, args.password, args.plate_id, args.server, args.port)
+
+    run(args.plate_id)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Been using this script again to populate Table on merge-ci.

It failed because we now need to call  `table.getOriginalFile()` *before* `table.close()`.

Also I updated the script to use `cli_login()` which is more convenient and secure than putting credentials as arguments.

To test:

```
$ omero login
$ python channel_minmax_to_table.py PLATE_ID
```